### PR TITLE
docs: clarify local build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ This places the binary in your Go bin directory (typically `$(go env GOPATH)/bin
 or `$GOBIN`). Make sure that directory is on your `$PATH` so you can run the
 tool directly.
 
-If you prefer to build from source after cloning the repository, run:
+If you prefer to build from source after cloning the repository, make sure you
+are inside the repository directory and then run:
 
 ```bash
+cd syncopa-core
 go build ./cmd/syncopa-core
 ```
 


### PR DESCRIPTION
## Summary
- update the README to clarify that local builds should be run from the repository directory
- add an explicit `cd syncopa-core` step before the `go build` command

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68df0a1a88c88325ab3f9741834410c2